### PR TITLE
Show Github stargazer counts in the timeline

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -158,8 +158,45 @@ import Timeline from "../components/Timeline.astro";
 
 		container.appendChild(p);
 		item.appendChild(container);
+
+        const stargazers = document.createElement("span")
+        stargazers.className = "stargazers";
+
+        p.appendChild(stargazers);
+
+        renderStargazersCount(server).then(span => {
+            if (span) {
+                stargazers.appendChild(span);
+            }
+        });
 		return item;
 	}
+
+    function getStargazersCount(url) {
+        const segments = url.split("/");
+        if (segments[2] !== "github.com") {
+            return Promise.resolve(undefined);
+        }
+        const owner = segments[3];
+        const repo = segments[4];
+        if (!owner || !repo) {
+            return Promise.resolve(undefined);
+        }
+
+        return fetch(`https://api.github.com/repos/${owner}/${repo}`, { cache: "force-cache" })
+            .then(response => response.json())
+            .then(data => data.stargazers_count);
+    }
+
+    function renderStargazersCount(server) {
+        return getStargazersCount(server.url).then(count => {
+            let span = document.createElement("span");
+            if (count !== undefined) {
+                span.textContent = ` (${count}\u2605)`;
+            }
+            return span;
+        });
+    }
 
 	render();
 
@@ -217,4 +254,9 @@ import Timeline from "../components/Timeline.astro";
 	.corner a {
 		text-decoration: none;
 	}
+
+    .stargazers {
+        font-size: 0.8rem;
+        color: #666;
+    }
 </style>


### PR DESCRIPTION
This PR makes a simple change to query the Github stargazer count for each listed repository using the public GitHub API.

![image](https://github.com/user-attachments/assets/d23f592d-9f3c-4633-8fe7-4e12f07bed28)
