### PR TITLE
fix steel

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -112,8 +112,8 @@ import Timeline from "../components/Timeline.astro";
 		},
 		{
 			name: "Steel MC",
-			url: "https://steel-foundation.github.io/SteelDocs/",
-			date: new Date("2025-10-16"), // Announced on the Pumpkin discord https://discord.com/channels/1268592337445978193/1268611318617866261/1427970155241013350
+			url: "https://steelmc.dev/",
+			date: new Date("2025-10-16"), // Announced on the reddit 28.7.2026 (before on pumpkin) https://www.reddit.com/r/rust/comments/1v93jfr/steelmc_a_rust_minecraft_server_generating_chunks/
 		},
 		{
 			name: "Spinel",


### PR DESCRIPTION
Two fixes:
- correct link to steel to the official domain
- as requested on the before PR, to have a proper announcement, it was done today, so added also the reddit link now.

Before fully open to the world, we wanted to have world generation parity 1:1 and that is achieved, as many other things.